### PR TITLE
Fix/1206020480964643 migration fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1776,6 +1776,7 @@ dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
+ "log",
  "pallet-balances",
  "pallet-sudo",
  "pallet-timestamp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,10 +17,9 @@ pallet-balances = { git = "https://github.com/peaqnetwork/substrate", branch = "
 pallet-sudo = { git = "https://github.com/peaqnetwork/substrate", branch = "peaq-polkadot-v0.9.43", default-features = false }
 pallet-timestamp = { git = "https://github.com/peaqnetwork/substrate", branch = "peaq-polkadot-v0.9.43", default-features = false }
 
-[dependencies.codec]
+[dependencies.parity-scale-codec]
 default-features = false
 features = ["derive"]
-package = "parity-scale-codec"
 version = "3.2.2"
 
 [dependencies.frame-benchmarking]
@@ -79,13 +78,13 @@ branch = "peaq-polkadot-v0.9.43"
 [features]
 default = ["std"]
 std = [
-    "codec/std",
     "frame-benchmarking/std",
     "frame-support/std",
     "frame-system/std",
     "pallet-balances/std",
     "pallet-sudo/std",
     "pallet-timestamp/std",
+    "parity-scale-codec/std",
     "peaq-pallet-did/std",
     "scale-info/std",
     "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,10 +74,15 @@ default-features = false
 git = "https://github.com/peaqnetwork/substrate"
 branch = "peaq-polkadot-v0.9.43"
 
+[dependencies.log]
+version = "0.4.17"
+default-features = false
+
 
 [features]
 default = ["std"]
 std = [
+	"log/std",
     "frame-benchmarking/std",
     "frame-support/std",
     "frame-system/std",

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,6 @@
 //! Encapsules all error types and relevant methods of this pallet.
 
-use codec::{Decode, Encode};
+use parity_scale_codec::{Decode, Encode};
 use peaq_pallet_did::did::DidError;
 #[cfg(feature = "std")]
 use serde::{Deserialize, Serialize};

--- a/src/error.rs
+++ b/src/error.rs
@@ -36,6 +36,8 @@ pub enum MorError {
     /// Sent when an unexpected Peaq-DID error occurs. This means, return
     /// to developer of the Peaq-MOR pallet.
     UnexpectedDidError,
+    /// Internal error happened
+    UnknownError,
 }
 
 impl From<DidError> for MorError {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -171,6 +171,7 @@ pub mod pallet {
     use frame_system::pallet_prelude::*;
     use sp_io::hashing::blake2_256;
     use sp_runtime::traits::{AccountIdConversion, One, Zero};
+    use sp_std::vec;
 
     use peaq_pallet_did::{did::Did, Pallet as DidPallet};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -159,8 +159,8 @@ pub use weightinfo::WeightInfo;
 #[frame_support::pallet]
 pub mod pallet {
 
-    use frame_support::{BoundedVec};
     use core::cmp::Ordering;
+    use frame_support::BoundedVec;
     use frame_support::{
         pallet_prelude::*,
         traits::{
@@ -171,7 +171,6 @@ pub mod pallet {
     use frame_system::pallet_prelude::*;
     use sp_io::hashing::blake2_256;
     use sp_runtime::traits::{AccountIdConversion, One, Zero};
-    use sp_std::{vec, vec::Vec};
 
     use peaq_pallet_did::{did::Did, Pallet as DidPallet};
 
@@ -458,10 +457,7 @@ pub mod pallet {
                 vec![BalanceOf::<T>::zero(); mor_config.track_n_block_rewards as usize]
                     .try_into()
                     .expect("bound checked in match arm condition; qed");
-            let reward_record = (
-                0u8,
-                yoyo,
-            );
+            let reward_record = (0u8, yoyo);
 
             MorConfigStorage::<T>::put(mor_config.clone());
             RewardsRecordStorage::<T>::put(reward_record);
@@ -524,7 +520,9 @@ pub mod pallet {
                 Ordering::Less => {
                     balances.resize(new_size, BalanceOf::<T>::zero());
                     let balances: BoundedVec<BalanceOf<T>, ConstU32<MAX_BLOCK_REWARD_NUM>> =
-                        balances.try_into().expect("bound checked in match arm condition; qed");
+                        balances
+                            .try_into()
+                            .expect("bound checked in match arm condition; qed");
                     let slot_cnt = cur_size as u8;
                     assert!(balances.len() == new_size);
                     RewardsRecordStorage::<T>::put((slot_cnt, balances));
@@ -533,7 +531,9 @@ pub mod pallet {
                     let slot_cnt = 0u8;
                     let balances = balances.split_off(cur_size - new_size);
                     let balances: BoundedVec<BalanceOf<T>, ConstU32<MAX_BLOCK_REWARD_NUM>> =
-                        balances.try_into().expect("bound checked in match arm condition; qed");
+                        balances
+                            .try_into()
+                            .expect("bound checked in match arm condition; qed");
                     assert!(balances.len() == new_size);
                     RewardsRecordStorage::<T>::put((slot_cnt, balances));
                 }

--- a/src/migrations.rs
+++ b/src/migrations.rs
@@ -26,11 +26,18 @@ mod v2 {
             let on_chain_version = Pallet::<T>::on_chain_storage_version();
 
             if on_chain_version < this_version {
+                log::info!(
+                    "Migrating storage from version {:?} to version {:?}",
+                    on_chain_version,
+                    this_version
+                );
+                // Translate the reward_rec
                 let reward_rec = RewardsRecordStorage::<T>::get();
-                let mor_config = MorConfig::<BalanceOf<T>>::default();
+                let mor_config = MorConfigStorage::<T>::get();
                 // This part, we only need to check whether the data is set before
                 // Therefore, once it not setup, we should reset it
                 if mor_config.track_n_block_rewards as usize != reward_rec.1.len() {
+                    log::info!("Resetting storage");
                     let mor_config = MorConfig::<BalanceOf<T>>::default();
                     Pallet::<T>::init_storages(&mor_config);
                     weight_writes += 3;

--- a/src/migrations.rs
+++ b/src/migrations.rs
@@ -1,0 +1,48 @@
+//! Storage migrations for the peaq-pallet-mor.
+
+use frame_support::{pallet_prelude::*, weights::Weight};
+
+use crate::{
+    pallet::*,
+    types::{BalanceOf, MorConfig},
+};
+
+pub(crate) fn on_runtime_upgrade<T: Config>() -> Weight {
+    v2::MigrateToV2x::<T>::on_runtime_upgrade()
+}
+
+mod v2 {
+    use super::*;
+
+    /// Migration implementation that renames storage HardCap into MaxCurrencySupply
+    pub struct MigrateToV2x<T>(sp_std::marker::PhantomData<T>);
+
+    impl<T: Config> MigrateToV2x<T> {
+        pub fn on_runtime_upgrade() -> Weight {
+            let mut weight_reads = 1;
+            let mut weight_writes = 0;
+
+            let this_version = Pallet::<T>::current_storage_version();
+            let on_chain_version = Pallet::<T>::on_chain_storage_version();
+
+            if on_chain_version < this_version {
+                let reward_rec = RewardsRecordStorage::<T>::get();
+                let mor_config = MorConfig::<BalanceOf<T>>::default();
+                // This part, we only need to check whether the data is set before
+                // Therefore, once it not setup, we should reset it
+                if mor_config.track_n_block_rewards as usize != reward_rec.1.len() {
+                    let mor_config = MorConfig::<BalanceOf<T>>::default();
+                    Pallet::<T>::init_storages(&mor_config);
+                    weight_writes += 3;
+                    weight_reads += 2;
+                    T::DbWeight::get().reads_writes(2, 3);
+                } else {
+                    weight_reads += 2;
+                    T::DbWeight::get().reads_writes(2, 0);
+                }
+                STORAGE_VERSION.put::<Pallet<T>>();
+            }
+            T::DbWeight::get().reads_writes(weight_reads, weight_writes)
+        }
+    }
+}

--- a/src/mor.rs
+++ b/src/mor.rs
@@ -22,7 +22,7 @@ pub trait MorBalance<AccountId, Balance> {
 
     /// When the configuration of the pallet will be changed, the storage size changes
     /// too. This method will reorganize the storage of the pallet and adapt its content.
-    fn resize_track_storage(new_size: u8);
+    fn resize_track_storage(new_size: u8) -> MorResult<()>;
 }
 
 /// The trait `MorMachine` encapsules adminstrative methods related to machines.

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,8 +1,7 @@
 //! All pallet relevant structs are defined here
 
-use codec::{Decode, Encode};
-use frame_support::traits::tokens::Balance as BalanceT;
-use frame_support::traits::Currency;
+use frame_support::traits::{tokens::Balance as BalanceT, Currency};
+use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
 use scale_info::TypeInfo;
 #[cfg(feature = "std")]
 use serde::{Deserialize, Serialize};
@@ -18,8 +17,11 @@ pub type WeightOf<T> = <T as crate::Config>::WeightInfo;
 /// This struct defines the configurable paramters of the Peaq-MOR pallet. All contained
 /// parameters can be configured by a dispatchable function (extrinsic).
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
-#[derive(PartialEq, Eq, Clone, Encode, Decode, RuntimeDebug, TypeInfo)]
-pub struct MorConfig<Balance> {
+#[derive(PartialEq, Eq, Clone, Encode, Decode, RuntimeDebug, TypeInfo, MaxEncodedLen)]
+pub struct MorConfig<Balance>
+where
+    Balance: BalanceT + MaxEncodedLen,
+{
     /// How much tokens a machine owner gets rewarded, when registering a new machine on the network.
     #[codec(compact)]
     pub registration_reward: Balance,


### PR DESCRIPTION
In this MR, I only focus on the migration issue but not introducing the other feature

Therefore, three main purposes are here
1. Add the migration version
2. Remove the without_storage_info because it should be in the production level (move the vec to BoundVec)
3. Add the error return to avoid the panic

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205464905577398